### PR TITLE
feat: fixed coin collect timer on lucky block

### DIFF
--- a/HeadUpDisplay.cpp
+++ b/HeadUpDisplay.cpp
@@ -1,8 +1,19 @@
 #include "pch.h"
-#include "HeadUpDisplay.h"
-#include "Debug.h"
-#include "Entity.h"
+#include "Animator.h"
 #include "AssetIDs.h"
+#include "Debug.h"
+#include "Game.h"
+#include "HeadUpDisplay.h"
+#include "SimpleMath.h"
+#include "SpriteBatch.h"
+#include "SpriteFont.h"
+#include "SpriteSheet.h"
+#include <cmath>
+#include <cstdio>
+#include <DirectXColors.h>
+#include <memory>
+#include <string>
+#include <Windows.h>
 
 constexpr auto RUNSPEED_THRESHOLD = 2.5f * 60.0f;
 constexpr auto MAX_FLIGHT_TIME = 255.f / 60.f;
@@ -101,11 +112,11 @@ void HeadUpDisplay::Render(DirectX::SpriteBatch* spriteBatch, DirectX::SpriteFon
 		m_animator->Draw(spriteBatch, ID_SPRITE_HUD_PMETER_BADGE_EMPTY, topLeft + (Vector2(113.f, 203.f) + Vector2(7.5f, 3.5f)) * scale, 0.0f, scale);
 	}
 
-	spriteFont->DrawString(spriteBatch, GetScoreChar(), topLeft + scorePos * scale, Colors::White, 0.f, Vector2::Zero, scale);
-	spriteFont->DrawString(spriteBatch, GetRTimeChar(), topLeft + timerPos * scale, Colors::White, 0.f, Vector2::Zero, scale);
-	spriteFont->DrawString(spriteBatch, GetCoinsChar(), topLeft + coinPos * scale, Colors::White, 0.f, Vector2::Zero, scale);
-	spriteFont->DrawString(spriteBatch, GetWorldChar(), topLeft + worldNumPos * scale, Colors::White, 0.f, Vector2::Zero, scale);
-	spriteFont->DrawString(spriteBatch, GetLivesChar(), topLeft + livesPos * scale, Colors::White, 0.f, Vector2::Zero, scale);
+	spriteFont->DrawString(spriteBatch, GetScoreChar(), topLeft + scorePos * scale, DirectX::Colors::White, 0.f, Vector2::Zero, scale);
+	spriteFont->DrawString(spriteBatch, GetRTimeChar(), topLeft + timerPos * scale, DirectX::Colors::White, 0.f, Vector2::Zero, scale);
+	spriteFont->DrawString(spriteBatch, GetCoinsChar(), topLeft + coinPos * scale, DirectX::Colors::White, 0.f, Vector2::Zero, scale);
+	spriteFont->DrawString(spriteBatch, GetWorldChar(), topLeft + worldNumPos * scale, DirectX::Colors::White, 0.f, Vector2::Zero, scale);
+	spriteFont->DrawString(spriteBatch, GetLivesChar(), topLeft + livesPos * scale, DirectX::Colors::White, 0.f, Vector2::Zero, scale);
 
 }
 
@@ -322,21 +333,21 @@ void HeadUpDisplay::SetMarioPowerupType(int powerupType) { m_currentPowerupType 
 
 int HeadUpDisplay::GetMarioPowerupType() const { return m_currentPowerupType; }
 
-const char* HeadUpDisplay::GetLivesChar()
+const char* HeadUpDisplay::GetLivesChar() const
 {
 	static char lives[3];
 	sprintf_s(lives, "%d", m_lives);
 	return lives;
 }
 
-const char* HeadUpDisplay::GetScoreChar()
+const char* HeadUpDisplay::GetScoreChar() const
 {
-	static char score[8];
+	static char score[8] = { 0 };
 	sprintf_s(score, "%07d", m_score);
 	return score;
 }
 
-const char* HeadUpDisplay::GetCoinsChar()
+const char* HeadUpDisplay::GetCoinsChar() const
 {
 	static char coinsBuffer[3];
 	sprintf_s(coinsBuffer, "%d", m_coins);

--- a/HeadUpDisplay.h
+++ b/HeadUpDisplay.h
@@ -63,9 +63,9 @@ private:
 	bool m_isTimerRunning;
 	float m_timeCounter;
 
-	const char* GetLivesChar();
-	const char* GetScoreChar();
-	const char* GetCoinsChar();
+	const char* GetLivesChar() const;
+	const char* GetScoreChar() const;
+	const char* GetCoinsChar() const;
 	const char* GetWorldChar() const;
 	const char* GetRTimeChar() const;
 

--- a/LuckyBlock.cpp
+++ b/LuckyBlock.cpp
@@ -1,13 +1,20 @@
 #include "pch.h"
 #include "AssetIDs.h"
+#include "Block.h"
+#include "Collision.h"
 #include "Debug.h"
-#include "LuckyBlock.h"
-#include "GameConfig.h"
-#include "Mario.h"
 #include "EffectManager.h"
-#include "World.h"
-#include "Mushroom.h"
 #include "FireLeaf.h"
+#include "Game.h"
+#include "LuckyBlock.h"
+#include "Mario.h"
+#include "MarioPowerUpStates.h"
+#include "Mushroom.h"
+#include "SimpleMath.h"
+#include "SpriteBatch.h"
+#include "SpriteSheet.h"
+#include "World.h"
+#include <string>
 
 LuckyBlock::LuckyBlock(Vector2 position, Vector2 size, bool isSolid, SpriteSheet* spriteSheet, bool isSpecial)
 	: Block(position, size, spriteSheet)
@@ -50,11 +57,13 @@ void LuckyBlock::Render(DirectX::SpriteBatch* spriteBatch)
 
 void LuckyBlock::Update(float dt)
 {
-	if (!m_collectedCoin) m_claimCoinTimer += dt;
-	if (m_claimCoinTimer > 0.5f && !m_collectedCoin) {
+	if (!m_collectedCoin && m_isClaimed) m_claimCoinTimer += dt;
+	if (m_claimCoinTimer > 0.7f && !m_collectedCoin) {
 		m_collectedCoin = true;
 
 		Game::GetInstance()->AddScore(100);
+
+		Log(LOG_INFO, "Collected Coin from LuckyBlock at: " + std::to_string(m_collisionComponent->GetPosition().x) + ", " + std::to_string(m_collisionComponent->GetPosition().y));
 
 	}
 	if (m_isClaiming) {

--- a/Wings.cpp
+++ b/Wings.cpp
@@ -1,7 +1,13 @@
 #include "pch.h"
-#include "Wings.h"
 #include "AssetIDs.h"
 #include "Debug.h"
+#include "Enemy.h"
+#include "Entity.h"
+#include "SimpleMath.h"
+#include "SpriteBatch.h"
+#include "SpriteSheet.h"
+#include "Wings.h"
+#include <vector>
 
 Wings::Wings(Vector2 position, Vector2 size, SpriteSheet* spriteSheet)
 	: Enemy(position, size, spriteSheet)
@@ -41,7 +47,8 @@ void Wings::Update(float dt)
 void Wings::Update(float dt, Vector2 ownerPosition, Vector2 ownerVelocity)
 {
 	if (!m_isActive) return;
-
+	ownerPosition;
+	ownerVelocity;
 	Entity::Update(dt);
 }
 


### PR DESCRIPTION
- Modified `GetLivesChar`, `GetScoreChar`, and `GetCoinsChar` to be `const` and initialized static arrays.
- Changed `Update` logic to check `m_isClaimed` and increased timer threshold for coin collection.
- Added logging for coin collection in `LuckyBlock`.